### PR TITLE
Modify cas logout url,use admin url in keycloak client configuration.

### DIFF
--- a/src/main/java/org/keycloak/protocol/cas/CASLoginProtocol.java
+++ b/src/main/java/org/keycloak/protocol/cas/CASLoginProtocol.java
@@ -109,14 +109,16 @@ public class CASLoginProtocol implements LoginProtocol {
 
     @Override
     public void backchannelLogout(UserSessionModel userSession, AuthenticatedClientSessionModel clientSession) {
-        String logoutUrl = clientSession.getRedirectUri();
-        String serviceTicket = clientSession.getNote(CASLoginProtocol.SESSION_SERVICE_TICKET);
-        //check if session is fully authenticated (i.e. serviceValidate has been called)
-        if (serviceTicket != null && !serviceTicket.isEmpty()) {
-            sendSingleLogoutRequest(logoutUrl, serviceTicket);
+        String logoutUrl = clientSession.getClient().getManagementUrl();
+        if (logoutUrl != null &&logoutUrl.equals("")) {
+            String serviceTicket = clientSession.getNote(CASLoginProtocol.SESSION_SERVICE_TICKET);
+            //check if session is fully authenticated (i.e. serviceValidate has been called)
+            if (serviceTicket != null && !serviceTicket.isEmpty()) {
+                sendSingleLogoutRequest(logoutUrl, serviceTicket);
+            }
+            ClientModel client = clientSession.getClient();
+            new ResourceAdminManager(session).logoutClientSession(uriInfo.getRequestUri(), realm, client, clientSession);
         }
-        ClientModel client = clientSession.getClient();
-        new ResourceAdminManager(session).logoutClientSession(uriInfo.getRequestUri(), realm, client, clientSession);
     }
 
     private void sendSingleLogoutRequest(String logoutUrl, String serviceTicket) {


### PR DESCRIPTION
In keycloak client config page.we know.URL to the admin interface of the client. Set this if the client supports the adapter REST API. This REST API allows the auth server to push revocation policies and other administrative tasks. Usually this is set to the base URL of the client.