### PR TITLE
Update to Keycloak 5.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,20 +13,20 @@ services:
   - docker
 
 env:
-  - KEYCLOAK_VERSION=4.8.3.Final
+  - KEYCLOAK_VERSION=5.0.0
 
 before_install:
-  - if [ "$TRAVIS_EVENT_TYPE" != "cron" ]; then docker pull jboss/keycloak:$KEYCLOAK_VERSION; fi
+  - if [ "$TRAVIS_EVENT_TYPE" != "cron" ]; then docker pull quay.io/keycloak/keycloak:$KEYCLOAK_VERSION; fi
 
 script:
   - if [ "$TRAVIS_EVENT_TYPE" != "cron" ]; then
       mvn test package -B &&
       mkdir target/docker &&
       cp target/*.jar target/docker/keycloak-protocol-cas.jar &&
-      echo "FROM jboss/keycloak:$KEYCLOAK_VERSION" > target/docker/Dockerfile &&
+      echo "FROM quay.io/keycloak/keycloak:$KEYCLOAK_VERSION" > target/docker/Dockerfile &&
       echo "ADD keycloak-protocol-cas.jar /opt/jboss/keycloak/standalone/deployments/" >> target/docker/Dockerfile &&
       cd target/docker && docker build -t doccrazy/keycloak-cas . && cd ../.. &&
-      docker run -d -p 127.0.0.1:8080:8080 --name keycloak -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin doccrazy/keycloak-cas && sleep 30 &&
+      docker run -d -p 127.0.0.1:8080:8080 --name keycloak -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin doccrazy/keycloak-cas && sleep 60 &&
       docker logs keycloak &&
       docker exec -t keycloak /opt/jboss/keycloak/bin/kcadm.sh config credentials --server http://localhost:8080/auth --realm master --user admin --password admin &&
       docker exec -t keycloak /opt/jboss/keycloak/bin/kcadm.sh create clients -r master -s clientId=test -s protocol=cas -s enabled=true -s publicClient=true -s 'redirectUris=["http://localhost/*"]' -s baseUrl=http://localhost -s adminUrl=http://localhost &&

--- a/pom.xml
+++ b/pom.xml
@@ -22,14 +22,14 @@
 
     <groupId>org.keycloak</groupId>
     <artifactId>keycloak-protocol-cas</artifactId>
-    <version>4.8.3</version>
+    <version>5.0.0</version>
     <name>Keycloak CAS Protocol</name>
     <description />
 
     <properties>
-        <keycloak.version>${project.version}.Final</keycloak.version>
-        <jboss.logging.version>3.3.0.Final</jboss.logging.version>
-        <jboss.logging.tools.version>2.0.1.Final</jboss.logging.tools.version>
+        <keycloak.version>${project.version}</keycloak.version>
+        <jboss.logging.version>3.3.2.Final</jboss.logging.version>
+        <jboss.logging.tools.version>2.1.0.Final</jboss.logging.tools.version>
         <junit.version>4.12</junit.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -124,6 +124,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifestEntries>


### PR DESCRIPTION
* Update Keycloak dependency, CI test image and project version for Keycloak release 5.0.0
* Adapt pom.xml, update.sh and .travis-ci.yml to new Keycloak versioning scheme
* Use new quay.io/keycloak/keycloak docker image
* Fix warning about missing maven-jar-plugin version