### PR TITLE
Error handling for debugging

### DIFF
--- a/src/main/java/org/keycloak/protocol/cas/endpoints/ValidateEndpoint.java
+++ b/src/main/java/org/keycloak/protocol/cas/endpoints/ValidateEndpoint.java
@@ -11,6 +11,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
+import java.util.UUID;
 
 public class ValidateEndpoint extends AbstractValidateEndpoint {
 
@@ -41,7 +42,16 @@ public class ValidateEndpoint extends AbstractValidateEndpoint {
             event.success();
             return successResponse();
         } catch (CASValidationException e) {
+            logger.info("CASValidationException :", e);
             return errorResponse(e);
+        } catch (Exception ex) {
+            // unexpected, probably not clients fault
+            final String uuid = UUID.randomUUID().toString();
+            logger.warn("CAS General exception [" + uuid + "] :", ex);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(uuid)
+                    .type(MediaType.TEXT_PLAIN)
+                    .build();
         }
     }
 

--- a/src/main/java/org/keycloak/protocol/cas/utils/ContentTypeHelper.java
+++ b/src/main/java/org/keycloak/protocol/cas/utils/ContentTypeHelper.java
@@ -3,7 +3,6 @@ package org.keycloak.protocol.cas.utils;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.keycloak.protocol.cas.CASLoginProtocol;
 
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.*;
 
 public class ContentTypeHelper {
@@ -26,7 +25,7 @@ public class ContentTypeHelper {
         try {
             Variant variant = restRequest.selectVariant(Variant.mediaTypes(MediaType.APPLICATION_XML_TYPE, MediaType.APPLICATION_JSON_TYPE).build());
             return variant == null ? MediaType.APPLICATION_XML_TYPE : variant.getMediaType();
-        } catch (BadRequestException e) {
+        } catch (Exception e) {
             //the default Accept header set by java.net.HttpURLConnection is invalid (cf. RESTEASY-960)
             return MediaType.APPLICATION_XML_TYPE;
         }


### PR DESCRIPTION
## Error handling tweaks

Recently was trying to use plugin on Keycloak (6.x), some minor tweaks that came out of it:

### Try catch in ContentTypeHelper
Changed the try cache exception - maybe because of using older version of keycloak? Or some classpath issues, as on my instance there was **org.jboss.resteasy.spi.BadRequestException** instead of javax.ws.rs.BadRequestException. Changed to general Exception as it really doesn´t matter why recognition failed.

### Logging general exception in ValidateEndpoint
Previous error was not easily debugged without it, as the exception was not logged properly. Had another issues with missing jaxb on classpath that needed to be properly logged as well. If something unexpected happens, it should be logged and at least some UUID of error added.