### PR TITLE
Update to Keycloak 9.0.0 and apply API change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ services:
   - docker
 
 env:
-  - KEYCLOAK_VERSION=8.0.0
+  - KEYCLOAK_VERSION=9.0.0
 
 before_install:
   - if [ "$TRAVIS_EVENT_TYPE" != "cron" ]; then docker pull quay.io/keycloak/keycloak:$KEYCLOAK_VERSION; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ services:
   - docker
 
 env:
-  - KEYCLOAK_VERSION=7.0.0
+  - KEYCLOAK_VERSION=8.0.0
 
 before_install:
   - if [ "$TRAVIS_EVENT_TYPE" != "cron" ]; then docker pull quay.io/keycloak/keycloak:$KEYCLOAK_VERSION; fi

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.keycloak</groupId>
     <artifactId>keycloak-protocol-cas</artifactId>
-    <version>8.0.0</version>
+    <version>9.0.0</version>
     <name>Keycloak CAS Protocol</name>
     <description />
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.keycloak</groupId>
     <artifactId>keycloak-protocol-cas</artifactId>
-    <version>7.0.0</version>
+    <version>8.0.0</version>
     <name>Keycloak CAS Protocol</name>
     <description />
 

--- a/src/main/java/org/keycloak/protocol/cas/CASLoginProtocol.java
+++ b/src/main/java/org/keycloak/protocol/cas/CASLoginProtocol.java
@@ -123,7 +123,7 @@ public class CASLoginProtocol implements LoginProtocol {
             sendSingleLogoutRequest(logoutUrl, serviceTicket);
         }
         ClientModel client = clientSession.getClient();
-        new ResourceAdminManager(session).logoutClientSession(uriInfo.getRequestUri(), realm, client, clientSession);
+        new ResourceAdminManager(session).logoutClientSession(realm, client, clientSession);
     }
 
     private void sendSingleLogoutRequest(String logoutUrl, String serviceTicket) {

--- a/src/main/java/org/keycloak/protocol/cas/endpoints/AbstractValidateEndpoint.java
+++ b/src/main/java/org/keycloak/protocol/cas/endpoints/AbstractValidateEndpoint.java
@@ -63,7 +63,7 @@ public abstract class AbstractValidateEndpoint {
 
         client = realm.getClients().stream()
                 .filter(c -> CASLoginProtocol.LOGIN_PROTOCOL.equals(c.getProtocol()))
-                .filter(c -> RedirectUtils.verifyRedirectUri(session.getContext().getUri(), service, realm, c) != null)
+                .filter(c -> RedirectUtils.verifyRedirectUri(session, service, c) != null)
                 .findFirst().orElse(null);
         if (client == null) {
             event.error(Errors.CLIENT_NOT_FOUND);

--- a/src/main/java/org/keycloak/protocol/cas/endpoints/AbstractValidateEndpoint.java
+++ b/src/main/java/org/keycloak/protocol/cas/endpoints/AbstractValidateEndpoint.java
@@ -153,7 +153,7 @@ public abstract class AbstractValidateEndpoint {
     protected Map<String, Object> getUserAttributes() {
         UserSessionModel userSession = clientSession.getUserSession();
         // CAS protocol does not support scopes, so pass null scopeParam
-        ClientSessionContext clientSessionCtx = DefaultClientSessionContext.fromClientSessionAndScopeParameter(clientSession, null);
+        ClientSessionContext clientSessionCtx = DefaultClientSessionContext.fromClientSessionAndScopeParameter(clientSession, null, session);
 
         Set<ProtocolMapperModel> mappings = clientSessionCtx.getProtocolMappers();
         KeycloakSessionFactory sessionFactory = session.getKeycloakSessionFactory();

--- a/src/main/java/org/keycloak/protocol/cas/endpoints/AuthorizationEndpoint.java
+++ b/src/main/java/org/keycloak/protocol/cas/endpoints/AuthorizationEndpoint.java
@@ -64,7 +64,7 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
 
         client = realm.getClients().stream()
                 .filter(c -> CASLoginProtocol.LOGIN_PROTOCOL.equals(c.getProtocol()))
-                .filter(c -> RedirectUtils.verifyRedirectUri(session.getContext().getUri(), service, realm, c) != null)
+                .filter(c -> RedirectUtils.verifyRedirectUri(session, service, c) != null)
                 .findFirst().orElse(null);
         if (client == null) {
             event.error(Errors.CLIENT_NOT_FOUND);
@@ -76,7 +76,7 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
             throw new ErrorPageException(session, Response.Status.BAD_REQUEST, Messages.CLIENT_DISABLED);
         }
 
-        redirectUri = RedirectUtils.verifyRedirectUri(session.getContext().getUri(), service, realm, client);
+        redirectUri = RedirectUtils.verifyRedirectUri(session, service, client);
 
         event.client(client.getClientId());
         event.detail(Details.REDIRECT_URI, redirectUri);

--- a/src/main/java/org/keycloak/protocol/cas/endpoints/LogoutEndpoint.java
+++ b/src/main/java/org/keycloak/protocol/cas/endpoints/LogoutEndpoint.java
@@ -72,10 +72,10 @@ public class LogoutEndpoint {
 
         client = realm.getClients().stream()
                 .filter(c -> CASLoginProtocol.LOGIN_PROTOCOL.equals(c.getProtocol()))
-                .filter(c -> RedirectUtils.verifyRedirectUri(session.getContext().getUri(), service, realm, c) != null)
+                .filter(c -> RedirectUtils.verifyRedirectUri(session, service, c) != null)
                 .findFirst().orElse(null);
         if (client != null) {
-            redirectUri = RedirectUtils.verifyRedirectUri(session.getContext().getUri(), service, realm, client);
+            redirectUri = RedirectUtils.verifyRedirectUri(session, service, client);
 
             session.getContext().setClient(client);
         }

--- a/src/main/java/org/keycloak/protocol/cas/representations/SAMLCASConstants.java
+++ b/src/main/java/org/keycloak/protocol/cas/representations/SAMLCASConstants.java
@@ -1,0 +1,11 @@
+package org.keycloak.protocol.cas.representations;
+
+public interface SAMLCASConstants {
+
+    String AUTH_METHOD_PASSWORD = "urn:oasis:names:tc:SAML:1.0:am:password";
+
+    String FORMAT_EMAIL_ADDRESS = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress";
+
+    String FORMAT_UNSPECIFIED = "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified";
+
+}

--- a/src/main/java/org/keycloak/protocol/cas/representations/SamlResponseHelper.java
+++ b/src/main/java/org/keycloak/protocol/cas/representations/SamlResponseHelper.java
@@ -74,7 +74,7 @@ public class SamlResponseHelper {
                             conditions.setNotOnOrAfter(factory.newXMLGregorianCalendar(GregorianCalendar.from(nowZoned.plusMinutes(5))));
                         }));
                         assertion.add(applyTo(new SAML11AuthenticationStatementType(
-                                URI.create(SAML11Constants.AUTH_METHOD_PASSWORD),
+                                URI.create(SAMLCASConstants.AUTH_METHOD_PASSWORD),
                                 now
                         ), stmt -> stmt.setSubject(toSubject(username))));
                         assertion.addAllStatements(toAttributes(username, attributes));
@@ -141,8 +141,8 @@ public class SamlResponseHelper {
 
     private static URI nameIdFormat(String username) {
         return URI.create(Validation.isEmailValid(username) ?
-                SAML11Constants.FORMAT_EMAIL_ADDRESS :
-                SAML11Constants.FORMAT_UNSPECIFIED
+                SAMLCASConstants.FORMAT_EMAIL_ADDRESS :
+                SAMLCASConstants.FORMAT_UNSPECIFIED
         );
     }
 


### PR DESCRIPTION
This PR is based on @kkovarik's 8.0.0 patch, and addresses API changes in 9.0.0:

- DefaultClientSessionContext.fromClientSessionAndScopeParameter adds session parm
- Add SAMLCASConstants to address removed constants from Keycloak